### PR TITLE
Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# OctoAcme Project Management Documentation
+ 
+## Overview
+
+This README provides an overview of the project management processes used by OctoAcme and links to all related documentation in the docs folder.
+ 
+## Project Management Process Summary
+
+OctoAcme follows a structured project lifecycle that includes planning, execution, monitoring, and delivery. Projects start with defining objectives, gathering requirements, and prioritizing tasks. Work moves through design, development, testing, and deployment phases to ensure smooth delivery.
+ 
+Clear roles and responsibilities ensure accountability and effective teamwork. Product Owners manage priorities, Project Managers oversee progress and risks, Developers implement solutions, and QA teams validate quality before releases.
+ 
+Communication is maintained through sprint planning, daily stand-ups, sprint reviews, and retrospectives. GitHub Issues and collaboration tools are used to track tasks, share updates, and resolve blockers efficiently.
+ 
+Quality assurance is built into every phase through code reviews, automated testing, acceptance criteria validation, and release approvals, ensuring reliable and high-quality outcomes.
+ 
+## Documentation Links
+
+- [Project Lifecycle](project-lifecycle.md)
+
+- [Roles and Responsibilities](roles-responsibilities.md)
+
+- [Communication Plan](communication-plan.md)
+
+
+
+ 


### PR DESCRIPTION
This pull request adds a README in the docs folder summarizing OctoAcme project management processes and linking all relevant documentation files.
Closes issue #<your-issue-number>